### PR TITLE
Fix io.grpc version.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,7 +37,7 @@
 	<dependency>
 	  <groupId>io.grpc</groupId>
 	  <artifactId>grpc-netty</artifactId>
-	  <version>1.20.0</version>
+	  <version>1.27.1</version>
 	</dependency>
 	<dependency>
 	  <groupId>junit</groupId>

--- a/proto-gen/pom.xml
+++ b/proto-gen/pom.xml
@@ -28,12 +28,12 @@
 	<dependency>
 	  <groupId>io.grpc</groupId>
 	  <artifactId>grpc-stub</artifactId>
-	  <version>1.20.0</version>
+	  <version>1.27.1</version>
 	</dependency>
 	<dependency>
 	  <groupId>io.grpc</groupId>
 	  <artifactId>grpc-protobuf</artifactId>
-	  <version>1.20.0</version>
+	  <version>1.27.1</version>
 	</dependency>
 	<dependency>
 	  <groupId>javax.annotation</groupId>


### PR DESCRIPTION
AbstractFutureStub was introduced in grpc 1.26.0.